### PR TITLE
fix latlng processing and update  README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,31 +2,6 @@
 
 サーバ側の実装
 
-## 動作環境(who3411)
-
-- macOS High Sierra(ver 10.13.6)
-- python 3.7.4
-- pip 19.0.3
-- MongoDB 4.2.0
-
-### MongoDB (Homebrew)
-
-[Install MongoDB Community Edition on macOS](https://docs.mongodb.com/manual/tutorial/install-mongodb-on-os-x/)を参考にした、Homebrewが入っている場合のMongoDBのインストール、および起動・停止方法
-
-#### インストール
-
-```
-$ brew tap mongodb/brew
-$ brew install mongodb-community
-```
-
-#### 起動・停止
-
-```
-$ brew services start mongodb-community #起動
-$ brew services stop mongodb-community  #停止
-```
-
 ## 必要なPythonパッケージ
 
 - Flask
@@ -42,7 +17,7 @@ pip install -r requirements.txt
 
 - アプリケーション側から送られてきた情報を保存する。
 
-### 情報の保存
+### 位置情報の保存
 
 アプリケーションから送られてきた情報を保存する。保存可能な情報は以下の通り。
 
@@ -116,7 +91,7 @@ pip install -r requirements.txt
 }
 ```
 
-### 情報の送信
+### 位置情報の送信
 
 アプリケーションから送られてきたリクエストを元に、これまで保存してきた情報を返す。各方法で指定された情報を `/sendLocation` にjson形式で送信することで、情報を送信する。サーバでは、送られてきた情報を処理し、以下の内容が含まれた情報を返す。
 

--- a/app.py
+++ b/app.py
@@ -12,7 +12,8 @@ app.config['JSON_AS_ASCII'] = False
 client = pymongo.MongoClient(app.config['HOST_MONGODB'], app.config['PORT_MONGODB'])
 db = client[app.config['NAME_DB']]
 collection = db[app.config['NAME_COLLECTION']]
-collection.create_index([('location', pymongo.GEOSPHERE)])
+#collection.create_index([('location', pymongo.GEOSPHERE)])
+collection.create_index([('location', pymongo.GEO2D)])
 
 def is_num(val):
     if val == None:
@@ -87,6 +88,7 @@ def send_location():
     # パラメータを元にクエリを作成
     if location != None:
         check_location(location, result)
+        location = [location[1], location[0]]
     else:
         result['isSave'] = 1
         result['errorstr'] = 'locationがありません。'
@@ -116,9 +118,7 @@ def send_location():
             result['errorstr'] = 'maxdistanceが数値ではありません。'
     if result['isSave'] == 0:
         if maxdistance == None:
-            query['location'] = {
-                '$near': {'$geometry': {'type':'Point', 'coordinates': [5, 5]}}
-            }
+            query['location'] = {'$near': location}
         else:
             query['location'] = {
                 '$geoWithin': {'$centerSphere': [location, maxdistance / 6378.137]}
@@ -149,6 +149,7 @@ def save_location():
         result['errorstr'] = 'locationがありません。'
 
     if result['isSave'] == 0:
+        data['location'] = [data['location'][1], data['location'][0]]
         insertData = {
             'location': data['location'],
             'title': None,


### PR DESCRIPTION
- 緯度経度に関するデータ処理の修正
     - mongodbのindexがlatlngを `[lng, lat]` 形式で保存しなければならないため、それに合わせました。
- README.mdの修正

