### PR TITLE
maxdistanceが指定されていないときに適切に場所情報を取得できていない問題を修正

### DIFF
--- a/app.py
+++ b/app.py
@@ -118,7 +118,9 @@ def send_location():
             result['errorstr'] = 'maxdistanceが数値ではありません。'
     if result['isSave'] == 0:
         if maxdistance == None:
-            query['location'] = {'$near': location}
+            query['location'] = {
+                '$geoWithin': {'$centerSphere': [location, 1 / 6378.137]}
+            }
         else:
             query['location'] = {
                 '$geoWithin': {'$centerSphere': [location, maxdistance / 6378.137]}

--- a/cmd/insert.py
+++ b/cmd/insert.py
@@ -1,0 +1,18 @@
+import fiona
+import requests
+import json
+
+file_name = './P30-13.shp'
+collection = fiona.open(file_name)
+
+for record in collection:
+    title = record['properties']['P30_005']
+    description = record['properties']['P30_006']
+    location = record['geometry']['coordinates']
+    print(title, description, location[0], location[1])
+    res = requests.post(
+        'http://localhost:5000/saveLocation',
+        json.dumps({'title': title, 'description': description, 'location': [location[1], location[0]]}),
+        headers={'Content-Type': 'application/json'}
+    )
+    print(res.json())


### PR DESCRIPTION
cmdディレクトリの中にJPGIS形式のshapeファイルを読み込んで，サーバーに流し込むスクリプトを追加して，実際に[国土数値情報　郵便局データの詳細](http://nlftp.mlit.go.jp/ksj/gml/datalist/KsjTmplt-P30.html)のデータを流し込んでチェックしたところ，適切に場所情報が取得できていなかったので修正しました